### PR TITLE
Add a finishing zero to the compositionBuffer

### DIFF
--- a/RAK811.cpp
+++ b/RAK811.cpp
@@ -34,6 +34,7 @@ char* convertBytesToString (uint8_t* inputBuffer, int inputSize) {
         c = inputBuffer[i] & 0xf;
         compositionBuffer[j++] = hexdigits[c];
     }
+    compositionBuffer[j++] = 0;
     return compositionBuffer;
 }
 


### PR DESCRIPTION
The compositionBuffer needs a last zero to indicate the end of the string to send. 

Right now the string that is sent ends with a random number of extra characters. This makes it impossible for Cayenne to decode the payload and might perhaps crash the device.

#https://github.com/PiSupply/RAK811-Arduino/issues/12#issue-909272472